### PR TITLE
🐞bug fix, Add time zone

### DIFF
--- a/GNews/Domain/API/NewsEndPoint.swift
+++ b/GNews/Domain/API/NewsEndPoint.swift
@@ -78,6 +78,7 @@ extension NewsAPI: APIBuilderProtocol {
     var newsDate: String {
         let date = Date()
         let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "America/Los_Angeles")
         dateFormatter.dateFormat = "YYYY-MM-dd"
         return dateFormatter.string(from: date)
     }


### PR DESCRIPTION
**Issue**
- No news articles shown if the US date and Japan date is different. Google news API date is mapped with US date.